### PR TITLE
Change from Prefixes to Patterns in ContextWording configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `IgnoredMetadata` configuration option to `RSpec/DescribeClass`. ([@Rafix02][])
 * Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
 * Fix a false positive for `RSpec/EmptyExampleGroup` when example is defined in an `if` branch. ([@koic][])
+* Change from `Prefixes` to `Patterns` in `ContextWording` configuration. ([@ken1flan][]
 
 ## 1.43.2 (2020-08-25)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -63,14 +63,14 @@ RSpec/ContextMethod:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextMethod
 
 RSpec/ContextWording:
-  Description: Checks that `context` docstring starts with an allowed prefix.
+  Description: Checks that `context` docstring matches an allowed pattern.
   Enabled: true
-  Prefixes:
-  - when
-  - with
-  - without
+  Patterns:
+  - ^when\b
+  - ^with\b
+  - ^without\b
   VersionAdded: '1.20'
-  VersionChanged: 1.20.1
+  VersionChanged: 1.43.3
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 
 RSpec/DescribeClass:

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -1,58 +1,101 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
-  let(:cop_config) { { 'Prefixes' => %w[when with] } }
+  let(:cop_config) { { 'Prefixes' => %w[when with], 'Patterns' => nil } }
 
-  it 'skips describe blocks' do
-    expect_no_offenses(<<-RUBY)
-      describe 'the display name not present' do
-      end
-    RUBY
+  context 'with Prefix settings' do
+    it 'skips describe blocks' do
+      expect_no_offenses(<<-RUBY)
+        describe 'the display name not present' do
+        end
+      RUBY
+    end
+
+    it 'finds context without `when` at the beginning' do
+      expect_offense(<<-RUBY)
+        context 'the display name not present' do
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Write context description like '^when\\b', or '^with\\b'.
+        end
+      RUBY
+    end
+
+    it 'finds shared_context without `when` at the beginning' do
+      expect_offense(<<-RUBY)
+        shared_context 'the display name not present' do
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Write context description like '^when\\b', or '^with\\b'.
+        end
+      RUBY
+    end
+
+    it "skips descriptions beginning with 'when'" do
+      expect_no_offenses(<<-RUBY)
+        context 'when the display name is not present' do
+        end
+      RUBY
+    end
+
+    it "skips descriptions beginning with 'when,'" do
+      expect_no_offenses(<<-RUBY)
+        context 'when, for some inexplicable reason, you inject a subordinate clause' do
+        end
+      RUBY
+    end
+
+    it 'finds context without separate `when` at the beginning' do
+      expect_offense(<<-RUBY)
+        context 'whenever you do' do
+                ^^^^^^^^^^^^^^^^^ Write context description like '^when\\b', or '^with\\b'.
+        end
+      RUBY
+    end
   end
 
-  it 'finds context without `when` at the beginning' do
-    expect_offense(<<-RUBY)
-      context 'the display name not present' do
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
-      end
-    RUBY
-  end
+  context 'with Pattern settings' do
+    let(:cop_config) { { 'Prefixes' => nil, 'Patterns' => %w[時$ ^もし.*ならば$] } }
 
-  it 'finds shared_context without `when` at the beginning' do
-    expect_offense(<<-RUBY)
-      shared_context 'the display name not present' do
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
-      end
-    RUBY
-  end
+    it 'skips describe blocks' do
+      expect_no_offenses(<<-RUBY)
+        describe 'the display name not present' do
+        end
+      RUBY
+    end
 
-  it "skips descriptions beginning with 'when'" do
-    expect_no_offenses(<<-RUBY)
-      context 'when the display name is not present' do
-      end
-    RUBY
-  end
+    it 'finds context without `時` at the ending' do
+      expect_offense(<<-RUBY)
+        context 'the display name not present' do
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Write context description like '時$', or '^もし.*ならば$'.
+        end
+      RUBY
+    end
 
-  it "skips descriptions beginning with 'when,'" do
-    expect_no_offenses(<<-RUBY)
-      context 'when, for some inexplicable reason, you inject a subordinate clause' do
-      end
-    RUBY
-  end
+    it 'finds shared_context without `時` at the ending' do
+      expect_offense(<<-RUBY)
+        shared_context 'the display name not present' do
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Write context description like '時$', or '^もし.*ならば$'.
+        end
+      RUBY
+    end
 
-  it 'finds context without separate `when` at the beginning' do
-    expect_offense(<<-RUBY)
-      context 'whenever you do' do
-              ^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
-      end
-    RUBY
+    it "skips descriptions ending with '時'" do
+      expect_no_offenses(<<-RUBY)
+        context 'display nameが存在しない時' do
+        end
+      RUBY
+    end
+
+    it "skips descriptions matching with '^もし.*ならば$'" do
+      expect_no_offenses(<<-RUBY)
+        context 'もしdisplay nameが存在しないならば' do
+        end
+      RUBY
+    end
   end
 
   context 'with metadata hash' do
     it 'finds context without separate `when` at the beginning' do
       expect_offense(<<-RUBY)
         context 'whenever you do', legend: true do
-                ^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
+                ^^^^^^^^^^^^^^^^^ Write context description like '^when\\b', or '^with\\b'.
         end
       RUBY
     end
@@ -62,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
     it 'finds context without separate `when` at the beginning' do
       expect_offense(<<-RUBY)
         context 'whenever you do', :legend do
-                ^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
+                ^^^^^^^^^^^^^^^^^ Write context description like '^when\\b', or '^with\\b'.
         end
       RUBY
     end
@@ -70,21 +113,22 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
 
   context 'with mixed metadata' do
     it 'finds context without separate `when` at the beginning' do
+      puts cop_config
       expect_offense(<<-RUBY)
         context 'whenever you do', :legend, myth: true do
-                ^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
+                ^^^^^^^^^^^^^^^^^ Write context description like '^when\\b', or '^with\\b'.
         end
       RUBY
     end
   end
 
   context 'when configured' do
-    let(:cop_config) { { 'Prefixes' => %w[if] } }
+    let(:cop_config) { { 'Prefixes' => %w[if], 'Patterns' => nil } }
 
     it 'finds context without allowed prefixes at the beginning' do
       expect_offense(<<-RUBY)
         context 'when display name is present' do
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Start context description with 'if'.
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Write context description like '^if\\b'.
         end
       RUBY
     end


### PR DESCRIPTION
Currently, only prefixes can be set in "Context Wording". 
However, in Japanese, when describing a condition, it may be a suffix such as `〜の場合`.
Therefore, I made it possible to describe with patterns so that it can be solved more flexibly.

Fixes issue番号




# memo

現在、ContextWordingでは接頭辞しか設定できません。日本語では条件を記述するときに`〜の場合`などのように接尾辞になることがあります。
そこで、より柔軟に解決できるようにパターンで記述できるようにしてみました。

## やったこと

RSpec/ContextWording`Patterns`で`Patterns`で推奨する`context`の書き方を指定できるようにしました。
既存の`Prefix`はそのまま利用できますが、Patternsに移行を促すwarningを出力するようにしました。

## 実装
プレフィクスのチェックはテキストをスペース区切りで分割して単語化し、その先頭の単語を検査していました。
これを単語化せずに正規表現によるパターンでチェックするように変えました。

既存のオプション`Prefixes`は`^when\s`のようにパターンに変換して、そのまま移行が必要ないようにしています。

## パフォーマンス
[forem](https://github.com/forem/forem)のコードに対し、下記スクリプトを実行しました。

<details>

```bash
LOG_BASE_DIR=tmp/rspec-context-wording
TIMES=20

mkdir -p $LOG_BASE_DIR

function example () {
  branch=$1
  RSPEC_RAILS_BRANCH=${branch} bundle install

  logfile=${LOG_BASE_DIR}/${branch}.log
  echo "---------- ${logfile} start"
  for i in `seq ${TIMES}`; do
    printf '.'
    RSPEC_RAILS_BRANCH=$branch time bundle exec rubocop --cache false --only RSpec/ContextWording 2>> $logfile
  done
  echo

  echo "---------- ${logfile} end"
}

function remove_logs () {
  rm -r ${LOG_BASE_DIR}/*.log
}

remove_logs
example master
example Use_patterns
```

</details>

### 実行結果

5.5%程度遅くなりそうです。

![image](https://user-images.githubusercontent.com/2942348/90956868-32c9d600-e4c5-11ea-9d5f-4ab637baf12e.png)

[データ](https://docs.google.com/spreadsheets/d/1-nRhFmLmx17t_PzyGjIaW1WneollONeYkIPit_sXpvU/edit?usp=sharing)


## 参照
- https://github.com/rubocop-hq/rubocop-jp/issues/49
